### PR TITLE
Export 'Showing' from Hoopl.Show

### DIFF
--- a/src/Compiler/Hoopl/Show.hs
+++ b/src/Compiler/Hoopl/Show.hs
@@ -4,7 +4,7 @@
 #endif
 
 module Compiler.Hoopl.Show 
-  ( showGraph, showFactBase
+  ( showGraph, showFactBase, Showing
   )
 where
 


### PR DESCRIPTION
GHC Trac user nimnul reports in
https://ghc.haskell.org/trac/ghc/ticket/10540:

  Hoopl exports

```
showGraph :: Showing n -> Graph n e x -> String
```

  But it doesn't export Showing. This doesn't make sense, as it's a
  user-supplied function. So to know what I should pass to showGraph I can only
  look at the source. :i Showing doesn't work.

  Below is a patch to export the innocent type synonym:
