### PR TITLE
Get rid of `#if CABAL` conditionals again

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`hoopl` package](http://hackage.haskell.org/package/hoopl)
 
+## ...
+
+ - replace `#if CABAL` macro by no CPP at all
+
 ## 3.10.1.1 *Aug 2015*
 
  - Add #if CABAL macro to several hoopl source files such that the Cabal generated macro is not included when building in ghci

--- a/src/Compiler/Hoopl/Fuel.hs
+++ b/src/Compiler/Hoopl/Fuel.hs
@@ -21,14 +21,7 @@ where
 import Compiler.Hoopl.Checkpoint
 import Compiler.Hoopl.Unique
 
-#if CABAL
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Applicative(..))
-#endif
-#else
-import Control.Applicative (Applicative(..))
-#endif
-
+import Control.Applicative as AP (Applicative(..))
 import Control.Monad (ap,liftM)
 
 class Monad m => FuelMonad m where
@@ -68,7 +61,7 @@ instance Monad m => Applicative (CheckingFuelMonad m) where
   (<*>) = ap
 
 instance Monad m => Monad (CheckingFuelMonad m) where
-  return = pure
+  return = AP.pure
   fm >>= k = FM (\f -> do { (a, f') <- unFM fm f; unFM (k a) f' })
 
 instance CheckpointMonad m => CheckpointMonad (CheckingFuelMonad m) where

--- a/src/Compiler/Hoopl/Graph.hs
+++ b/src/Compiler/Hoopl/Graph.hs
@@ -46,13 +46,7 @@ import Compiler.Hoopl.Collections
 import Compiler.Hoopl.Block
 import Compiler.Hoopl.Label
 
-#if CABAL
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Applicative(..))
-#endif
-#else
-import Control.Applicative (Applicative(..))
-#endif
+import Control.Applicative as AP (Applicative(..))
 import Control.Monad (ap,liftM,liftM2)
 
 -- -----------------------------------------------------------------------------
@@ -362,7 +356,7 @@ instance Applicative VM where
   (<*>) = ap
 
 instance Monad VM where
-  return = pure
+  return = AP.pure
   m >>= k  = VM $ \visited -> let (a, v') = unVM m visited in unVM (k a) v'
 
 marked :: Label -> VM Bool

--- a/src/Compiler/Hoopl/Unique.hs
+++ b/src/Compiler/Hoopl/Unique.hs
@@ -24,14 +24,7 @@ import Compiler.Hoopl.Collections
 import qualified Data.IntMap as M
 import qualified Data.IntSet as S
 
-#ifdef CABAL
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
-#else
-import Control.Applicative
-#endif
-
+import Control.Applicative as AP
 import Control.Monad (ap,liftM)
 
 -----------------------------------------------------------------------------
@@ -127,7 +120,7 @@ instance Applicative SimpleUniqueMonad where
   (<*>) = ap
 
 instance Monad SimpleUniqueMonad where
-  return = pure
+  return = AP.pure
   m >>= k  = SUM $ \us -> let (a, us') = unSUM m us in
                               unSUM (k a) us'
 

--- a/testing/OptSupport.hs
+++ b/testing/OptSupport.hs
@@ -6,14 +6,7 @@ import Control.Monad
 import Data.Maybe
 import Prelude hiding (succ)
 
-#if CABAL
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Applicative(..))
-#endif
-#else
-import Control.Applicative (Applicative(..))
-#endif
-
+import Control.Applicative as AP (Applicative(..))
 import Compiler.Hoopl hiding ((<*>))
 import IR
 
@@ -35,8 +28,10 @@ mapVE _ _       = Nothing
 
 
 data Mapped a = Old a | New a
+
 instance Monad Mapped where
-  return = Old
+  return = AP.pure
+
   Old a >>= k = k a
   New a >>= k = asNew (k a)
     where asNew (Old a)   = New a
@@ -46,7 +41,7 @@ instance Functor Mapped where
   fmap = liftM
 
 instance Applicative Mapped where
-  pure = return
+  pure = Old
   (<*>) = ap
 
 


### PR DESCRIPTION
Those were introduced via 814d4ef37ef3b5f2dfeddced3875cbd3e8b375b1
but there's actually a more elegant way to avoid redundant imports
in combination with MRP-style refactoring
(as started in 20fad2ed91cd78ed8b9bd92aae1ecfdfb8350d2f)
