### PR TITLE
Guard redundant equations

### DIFF
--- a/src/Compiler/Hoopl/Dataflow.hs
+++ b/src/Compiler/Hoopl/Dataflow.hs
@@ -247,7 +247,9 @@ arfGraph pass@FwdPass { fp_lattice = lattice,
                 -> Fact e f -> m (DG f n e C, Fact C f)
              c NothingC (JustO entry)   = block entry `cat` body (successors entry) bdy
              c (JustC entries) NothingO = body entries bdy
+#if __GLASGOW_HASKELL__ < 711
              c _ _ = error "bogus GADT pattern match failure"
+#endif
 
     -- Lift from nodes to blocks
 -- @ start block.tex -2
@@ -439,7 +441,9 @@ arbGraph pass@BwdPass { bp_lattice  = lattice,
                 -> Fact C f -> m (DG f n e C, Fact e f)
              c NothingC (JustO entry)   = block entry `cat` body (successors entry) bdy
              c (JustC entries) NothingO = body entries bdy
+#if __GLASGOW_HASKELL__ < 711
              c _ _ = error "bogus GADT pattern match failure"
+#endif
 
     -- Lift from nodes to blocks
     block BNil          = \f -> return (dgnil, f)

--- a/src/Compiler/Hoopl/Graph.hs
+++ b/src/Compiler/Hoopl/Graph.hs
@@ -193,7 +193,9 @@ splice bcat = sp
         sp (GMany e1 b1 NothingO) (GMany NothingO b2 x2)
           = {-# SCC "sp5" #-} (GMany e1 $! b1 `bodyUnion` b2) x2
 
+#if __GLASGOW_HASKELL__ < 711
         sp _ _ = error "bogus GADT match failure"
+#endif
 
 gSplice :: NonLocal n => Graph n e a -> Graph n a x -> Graph n e x
 gSplice = splice blockAppend


### PR DESCRIPTION
GHC's exhaustiveness checker used to be quite rudimentary. As of GHC
8.0 we have a new exhaustiveness checker which correctly recognizes the
cases covered by these equations as invalid.
