### PR TITLE
Prefix unused type variables with an underscore.

### DIFF
--- a/src/Compiler/Hoopl/Block.hs
+++ b/src/Compiler/Hoopl/Block.hs
@@ -58,8 +58,8 @@ data C
 
 -- | Either type indexed by closed/open using type families
 type family IndexedCO ex a b :: *
-type instance IndexedCO C a b = a
-type instance IndexedCO O a b = b
+type instance IndexedCO C a _b = a
+type instance IndexedCO O _a b = b
 
 -- | Maybe type indexed by open/closed
 data MaybeO ex t where


### PR DESCRIPTION
I'm working on adding warnings about unused type variables in type/data families. (https://ghc.haskell.org/trac/ghc/ticket/10982) However, after my changes, new warnings appear during the compilation of hoopl, which interrupts the ghc validation. This patch prefixes the unused type variables with underscores, suppressing the warnings. 
