### PR TITLE
Remove crufty testcoverage flag for --enable-coverage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run the tests in the `testing/` folder run:
 
 To run the tests with the test coverage report run:
 
-    cabal configure --enable-tests -f testcoverage
+    cabal configure --enable-tests --enable-coverage
     cabal test
 
 You'll need a Haskell Platform, which should include appropriate

--- a/hoopl.cabal
+++ b/hoopl.cabal
@@ -24,11 +24,6 @@ Source-repository head
   Type:       git
   Location:   http://git.haskell.org/packages/hoopl.git
 
-flag testcoverage 
-  description: Enable test coverage report
-  default: False
-
-
 Library
   Default-Language:  Haskell2010
   Other-Extensions:  CPP
@@ -84,6 +79,3 @@ Test-Suite hoopl-test
                      test-framework < 0.9,
                      test-framework-hunit < 0.4,
                      mtl >= 2.1.3.1
-
-  if flag(testcoverage) 
-    Ghc-Options: -fhpc


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
