### PR TITLE
Fix dominator join function.

### DIFF
--- a/src/Compiler/Hoopl/Passes/Dominator.hs
+++ b/src/Compiler/Hoopl/Passes/Dominator.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, GADTs #-}
 {-# OPTIONS_GHC -Wall -fno-warn-name-shadowing #-}
-#if __GLASGOW_HASKELL__ >= 701
+#if __GLASGOW_HASKELL__ >= 723
 {-# LANGUAGE Safe #-}
 #endif
 

--- a/src/Compiler/Hoopl/Passes/Dominator.hs
+++ b/src/Compiler/Hoopl/Passes/Dominator.hs
@@ -48,8 +48,10 @@ domLattice = addPoints "dominators" extend
 extend :: JoinFun DPath
 extend _ (OldFact (DPath l)) (NewFact (DPath l')) =
                                 (changeIf (l `lengthDiffers` j), DPath j)
-    where j = filter (\elem -> Set.member elem common) l
+    where lx = filter (\elem -> Set.member elem common) l
+          rx = filter (\elem -> Set.member elem common) l'
           common = Set.intersection (Set.fromList l) (Set.fromList l')
+          j = [x | (x, y) <- zip lx rx, x == y]
 
           lengthDiffers [] [] = False
           lengthDiffers (_:xs) (_:ys) = lengthDiffers xs ys

--- a/src/Compiler/Hoopl/Passes/Dominator.hs
+++ b/src/Compiler/Hoopl/Passes/Dominator.hs
@@ -13,6 +13,7 @@ module Compiler.Hoopl.Passes.Dominator
 where
 
 import Data.Maybe
+import qualified Data.Set as Set
 
 import Compiler.Hoopl
 
@@ -47,15 +48,8 @@ domLattice = addPoints "dominators" extend
 extend :: JoinFun DPath
 extend _ (OldFact (DPath l)) (NewFact (DPath l')) =
                                 (changeIf (l `lengthDiffers` j), DPath j)
-    where j = lcs l l'
-          lcs :: [Label] -> [Label] -> [Label] -- longest common suffix
-          lcs l l' | length l > length l' = lcs (drop (length l - length l') l) l'
-                   | length l < length l' = lcs l' l
-                   | otherwise = dropUnlike l l' l
-          dropUnlike [] [] maybe_like = maybe_like
-          dropUnlike (x:xs) (y:ys) maybe_like =
-              dropUnlike xs ys (if x == y then maybe_like else xs)
-          dropUnlike _ _ _ = error "this can't happen"
+    where j = filter (\elem -> Set.member elem common) l
+          common = Set.intersection (Set.fromList l) (Set.fromList l')
 
           lengthDiffers [] [] = False
           lengthDiffers (_:xs) (_:ys) = lengthDiffers xs ys


### PR DESCRIPTION
Hoopl's dominator pass computes incorrect dominators for the following control flow graph:

```
              664
             +  +
             |  |
    690 <----+  +------->
     +                   691
     |                   + +
     v             683 <-+ +-> 684
    721  <-----+     +         +
     + +       |     |         |
  +--+ +--+    |     |         |
  v       v    |     +-> 685 <-+
677      678   |          +
               +----------+
```

Note there are two paths, of differing lengths, from the entry (664) to node 721.

The LCS-based join function produces the following:

```
dominators transfer: L721 -> L664 -> entry -> ((BR to 677 or 678)) -> [(L677,L721 -> L664 -> entry),(L678,L721 -> L664 -> entry)]
+ Join@L678: L721 -> L690 -> L664 -> entry `join` L721 -> L664 -> entry = L664 -> entry
+ Join@L677: L721 -> L690 -> L664 -> entry `join` L721 -> L664 -> entry = L664 -> entry
```
Because of the "stray" L690 in the middle, the LCS is computed to be just the root of the graph; L721 is dropped, incorrectly.

I think the right fix is to forget about suffixes, and just filter by set intersection.