### PR TITLE
Fix deprecation warnings from containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: c
 sudo: required
 
 env:
- - CABALVER=1.16 GHCVER=7.0.1
  - CABALVER=1.16 GHCVER=7.0.4
  - CABALVER=1.16 GHCVER=7.2.2
  - CABALVER=1.16 GHCVER=7.4.2

--- a/hoopl.cabal
+++ b/hoopl.cabal
@@ -41,7 +41,7 @@ Library
 
   Hs-Source-Dirs:    src
   Build-Depends:     base >= 4.3 && < 4.11,
-                     containers >= 0.4 && < 0.6
+                     containers >= 0.5 && < 0.6
   Exposed-Modules:   Compiler.Hoopl,
                      Compiler.Hoopl.Internals,
                      Compiler.Hoopl.Wrappers,
@@ -72,8 +72,8 @@ Test-Suite hoopl-test
   Type:              exitcode-stdio-1.0
   Main-Is:           Main.hs
   Hs-Source-Dirs:    testing src
-  Build-Depends:     base >= 4.3 && < 4.10, 
-                     containers >= 0.4 && < 0.6,
+  Build-Depends:     base >= 4.3 && < 4.10,
+                     containers >= 0.5 && < 0.6,
                      filepath,
                      mtl >= 2.1.3.1,
                      parsec >= 3.1.7,

--- a/src/Compiler/Hoopl/Unique.hs
+++ b/src/Compiler/Hoopl/Unique.hs
@@ -100,8 +100,8 @@ instance IsMap UniqueMap where
 
   mapMap f (UM m) = UM (M.map f m)
   mapMapWithKey f (UM m) = UM (M.mapWithKey (f . intToUnique) m)
-  mapFold k z (UM m) = M.fold k z m
-  mapFoldWithKey k z (UM m) = M.foldWithKey (k . intToUnique) z m
+  mapFold k z (UM m) = M.foldr k z m
+  mapFoldWithKey k z (UM m) = M.foldrWithKey (k . intToUnique) z m
   mapFilter f (UM m) = UM (M.filter f m)
 
   mapElems (UM m) = M.elems m


### PR DESCRIPTION
Also bumps the lower bound on containers to `>= 0.5` which should be fine
since `0.5.0.0` ws released in 2012.