### PR TITLE
Use non-deprecated Map and Set folds

### DIFF
--- a/src/Compiler/Hoopl/Unique.hs
+++ b/src/Compiler/Hoopl/Unique.hs
@@ -66,7 +66,7 @@ instance IsSet UniqueSet where
   setIntersection (US x) (US y) = US (S.intersection x y)
   setIsSubsetOf (US x) (US y) = S.isSubsetOf x y
 
-  setFold k z (US s) = S.fold k z s
+  setFold k z (US s) = S.foldr k z s
 
   setElems (US s) = S.elems s
   setFromList ks = US (S.fromList ks)


### PR DESCRIPTION
`fold` and `foldWithKey` are now deprecated in `containers`.
This package's use causes GHC validation to fail with
`containers-0.5.10.1`.