### PR TITLE
Update version for compatibility with base-4.11.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog for [`hoopl` package](http://hackage.haskell.org/package/hoopl)
 
+## 3.10.2.3 *Mar 2018*
+  Update for compatibility with GHC 8.4.1 and base-4.11.
+
 ## 3.10.2.2 *Feb 2017*
   This release includes non-API changes.
 

--- a/hoopl.cabal
+++ b/hoopl.cabal
@@ -1,5 +1,5 @@
 Name:                hoopl
-Version:             3.10.2.2
+Version:             3.10.2.3
 -- NOTE: Don't forget to update ./changelog.md
 Description:
   Higher-order optimization library
@@ -40,7 +40,7 @@ Library
     Other-Extensions: Safe Trustworthy
 
   Hs-Source-Dirs:    src
-  Build-Depends:     base >= 4.3 && < 4.11,
+  Build-Depends:     base >= 4.3 && < 4.12,
                      containers >= 0.5 && < 0.6
   Exposed-Modules:   Compiler.Hoopl,
                      Compiler.Hoopl.Internals,


### PR DESCRIPTION
GHC 8.4.1 ships with base version 4.11.

I bumped the version limit from 4.11 to 4.12 (rather than, say, 5) to err on the side of caution. Maybe 5 is a better bound? I'm not sure what the prevailing philosophy is these days.