### PR TITLE
Changes for GHC 8.10 and 9.0

### DIFF
--- a/hoopl.cabal
+++ b/hoopl.cabal
@@ -38,7 +38,9 @@ tested-with:         GHC == 7.0.4,
                      GHC == 8.0.2,
                      GHC == 8.2.2,
                      GHC == 8.4.3,
-                     GHC == 8.6.1
+                     GHC == 8.6.1,
+                     GHC == 8.10.7,
+                     GHC == 9.0.1
 
 Source-repository head
   Type:       git
@@ -60,7 +62,7 @@ Library
     Other-Extensions: Safe Trustworthy
 
   Hs-Source-Dirs:    src
-  Build-Depends:     base >= 4.3 && < 4.13,
+  Build-Depends:     base >= 4.3 && < 4.16,
                      containers >= 0.5 && < 0.7
   Exposed-Modules:   Compiler.Hoopl,
                      Compiler.Hoopl.Internals,
@@ -106,7 +108,7 @@ Test-Suite hoopl-test
                      Simplify
                      Test
   Hs-Source-Dirs:    testing
-  Build-Depends:     base >= 4.3 && < 4.13,
+  Build-Depends:     base >= 4.3 && < 4.16,
                      containers >= 0.5 && < 0.7,
                      filepath,
                      hoopl,

--- a/src/Compiler/Hoopl/Dataflow.hs
+++ b/src/Compiler/Hoopl/Dataflow.hs
@@ -291,7 +291,7 @@ arfGraph pass@FwdPass { fp_lattice = lattice,
 -- We know the results _shouldn't change_, but the transfer
 -- functions might, for example, generate some debugging traces.
 joinInFacts :: DataflowLattice f -> FactBase f -> FactBase f
-joinInFacts (lattice @ DataflowLattice {fact_bot = bot, fact_join = fj}) fb =
+joinInFacts (lattice@DataflowLattice {fact_bot = bot, fact_join = fj}) fb =
   mkFactBase lattice $ map botJoin $ mapToList fb
     where botJoin (l, f) = (l, snd $ fj l (OldFact bot) (NewFact f))
 

--- a/src/Compiler/Hoopl/MkGraph.hs
+++ b/src/Compiler/Hoopl/MkGraph.hs
@@ -147,10 +147,10 @@ class Uniques u where
   withFresh :: (u -> AGraph n e x) -> AGraph n e x
 
 instance Uniques Unique where
-  withFresh f = A $ freshUnique >>= (graphOfAGraph . f)
+  withFresh f = A $ freshUnique >>= (\ z -> graphOfAGraph $ f z)
 
 instance Uniques Label where
-  withFresh f = A $ freshUnique >>= (graphOfAGraph . f . uniqueToLbl)
+  withFresh f = A $ freshUnique >>= (\ z -> graphOfAGraph $ f $ uniqueToLbl z)
 
 -- | Lifts binary 'Graph' functions into 'AGraph' functions.
 liftA2 :: (Graph  n a b -> Graph  n c d -> Graph  n e f)


### PR DESCRIPTION
Bumped base bounds for GHC 8.10 and 9.0 and made changes to accommodate simplified subsumption and whitespace-sensitive operator parsing.